### PR TITLE
Makes sure viewer's stylesheet uses media:all for printing

### DIFF
--- a/app/views/pdfjs_viewer/viewer/_viewer.html.erb
+++ b/app/views/pdfjs_viewer/viewer/_viewer.html.erb
@@ -31,7 +31,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <title><%= title %></title>
 
 
-    <%= stylesheet_link_tag "pdfjs_viewer/application" %>
+    <%= stylesheet_link_tag "pdfjs_viewer/application", media: "all" %>
 
     <!-- This snippet is used in production (included from viewer.html) -->
     <link rel="resource" type="application/l10n" href="/pdfjs/web/locale/locale.properties"/>


### PR DESCRIPTION
http://apidock.com/rails/ActionView/Helpers/AssetTagHelper/stylesheet_link_tag 

defaults to screen, so we end up not using the media print in the css.

I changed it to media: all in the viewer file