### PR TITLE
Disable cross-origin check

### DIFF
--- a/app/assets/javascripts/pdfjs_viewer/viewer.js
+++ b/app/assets/javascripts/pdfjs_viewer/viewer.js
@@ -7145,30 +7145,30 @@ window.PDFView = PDFViewerApplication; // obsolete name, using it as an alias
 var HOSTED_VIEWER_ORIGINS = ['null',
   'http://mozilla.github.io', 'https://mozilla.github.io'];
 function validateFileURL(file) {
-  try {
-    var viewerOrigin = new URL(window.location.href).origin || 'null';
-    if (HOSTED_VIEWER_ORIGINS.indexOf(viewerOrigin) >= 0) {
-      // Hosted or local viewer, allow for any file locations
-      return;
-    }
-    var fileOrigin = new URL(file, window.location.href).origin;
-    // Removing of the following line will not guarantee that the viewer will
-    // start accepting URLs from foreign origin -- CORS headers on the remote
-    // server must be properly configured.
-    if (fileOrigin !== viewerOrigin) {
-      throw new Error('file origin does not match viewer\'s');
-    }
-  } catch (e) {
-    var message = e && e.message;
-    var loadingErrorMessage = mozL10n.get('loading_error', null,
-      'An error occurred while loading the PDF.');
+//   try {
+//     var viewerOrigin = new URL(window.location.href).origin || 'null';
+//     if (HOSTED_VIEWER_ORIGINS.indexOf(viewerOrigin) >= 0) {
+//       // Hosted or local viewer, allow for any file locations
+//       return;
+//     }
+//     var fileOrigin = new URL(file, window.location.href).origin;
+//     // Removing of the following line will not guarantee that the viewer will
+//     // start accepting URLs from foreign origin -- CORS headers on the remote
+//     // server must be properly configured.
+//     if (fileOrigin !== viewerOrigin) {
+//       throw new Error('file origin does not match viewer\'s');
+//     }
+//   } catch (e) {
+//     var message = e && e.message;
+//     var loadingErrorMessage = mozL10n.get('loading_error', null,
+//       'An error occurred while loading the PDF.');
 
-    var moreInfo = {
-      message: message
-    };
-    PDFViewerApplication.error(loadingErrorMessage, moreInfo);
-    throw e;
-  }
+//     var moreInfo = {
+//       message: message
+//     };
+//     PDFViewerApplication.error(loadingErrorMessage, moreInfo);
+//     throw e;
+//   }
 }
 
 function webViewerLoad(evt) {


### PR DESCRIPTION
The viewer for PDF.js does its own cross-origin checks, refusing to load any remote PDFs, which stops the viewer loading PDFs from CDNs or remote storage locations, such as S3.