### PR TITLE
make the verbosity configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ an iframe.
 
 NOTE: The helper will render a full HTML document and should not be used in a layout.
 
+### Verbosity of PDF.js
+
+The verbosity of PDF.js can be set with:
+
+```
+$ export PDFJS_VIEWER_VERBOSITY=warnings
+```
+
+Verbosity levels:
+
+* errors (default)
+* warnings
+* infos
+
 ## Development
 
 Tests can be executed with:

--- a/app/assets/javascripts/pdfjs_viewer/application.js
+++ b/app/assets/javascripts/pdfjs_viewer/application.js
@@ -14,3 +14,4 @@
 //= require pdfjs_viewer/pdfjs/pdf.combined
 //= require pdfjs_viewer/pdfjs/l10n
 //= require pdfjs_viewer/viewer
+//= require pdfjs_viewer/configurations

--- a/app/assets/javascripts/pdfjs_viewer/configurations.js.erb
+++ b/app/assets/javascripts/pdfjs_viewer/configurations.js.erb
@@ -1,0 +1,2 @@
+var verbosity = document.querySelector('meta[name="pdfjs_viewer_verbosity"]').content;
+PDFJS.verbosity = PDFJS.VERBOSITY_LEVELS[verbosity];

--- a/app/views/pdfjs_viewer/viewer/_viewer.html.erb
+++ b/app/views/pdfjs_viewer/viewer/_viewer.html.erb
@@ -28,6 +28,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="pdfjs_viewer_verbosity" content="<%= ENV.fetch("PDFJS_VIEWER_VERBOSITY", "errors") %>">
     <title><%= title %></title>
 
 

--- a/test/integration/viewer_test.rb
+++ b/test/integration/viewer_test.rb
@@ -49,6 +49,20 @@ class ViewerTest < ActionDispatch::IntegrationTest
     assert_rendered_pdf output, screenshot: SANDBOX_PATH + "helper.png"
   end
 
+  test "pdfjs viewer verbosity is set with ENV variable" do
+    begin
+      ENV["PDFJS_VIEWER_VERBOSITY"] = "warnings"
+      output = capture(:stdout) do
+        visit "/"
+        click_on "full viewer"
+        assert_equal 1, page.evaluate_script("PDFJS.verbosity")
+      end
+      assert_includes output, "Warning: Setting up fake worker"
+    ensure
+      ENV.delete("PDFJS_VIEWER_VERBOSITY")
+    end
+  end
+
   private
   def assert_rendered_pdf(output, screenshot:)
     puts output.scan(/Warning:.+$/)


### PR DESCRIPTION
closes #10 

Why did I use a `meta` tag to provide the verbosity?

Because.. When a javascript file is compiled (ENV variable written to code), the js file never get's updated unless you change it. So if you set the `ENV["PDFJS_VIEWER_VERBOSITY"] = "warnings"`, then start your server, the verbosity will be "warnings". 
If you then stop your server and change the ENV variable: `ENV["PDFJS_VIEWER_VERBOSITY"] = "errors"` and start your server back up, this won't take any affect, because the javascript file stays the same.

But in the view, this is always updated when the view is loaded. (As views are not precompiled).  
So I placed the verbosity as a `meta` tag inside the viewer's view and then write the javscript to set it.

/cc @shanear 
