### PR TITLE
Configurable viewer origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ an iframe.
 
 NOTE: The helper will render a full HTML document and should not be used in a layout.
 
+### Cross-origin checks
+
+To enable loading of PDFs at remote hosts, the following configuration option must be set in an initialiser:
+
+  ```ruby
+  PdfjsViewer.hosted_viewer_origins = ["http://yourhost.com", "https://yourhost.com"]
+  ```
+
+Replacing `yourhost.com` for your own domain. CORS headers must still be set correctly on the remote host.
+
 ## Development
 
 Tests can be executed with:

--- a/app/views/pdfjs_viewer/viewer/_viewer.html.erb
+++ b/app/views/pdfjs_viewer/viewer/_viewer.html.erb
@@ -42,6 +42,7 @@ See https://github.com/adobe-type-tools/cmap-resources
       </script>
     <% end %>
     <%= javascript_include_tag "pdfjs_viewer/application" %>
+    <%= javascript_tag "window.HOSTED_VIEWER_ORIGINS = #{PdfjsViewer.hosted_viewer_origins.to_json.html_safe};" %>
   </head>
 
   <body tabindex="1" class="loadingInProgress" id="pdfjs_viewer-<%= style %>">

--- a/lib/pdfjs_viewer-rails.rb
+++ b/lib/pdfjs_viewer-rails.rb
@@ -2,6 +2,12 @@ require "pdfjs_viewer-rails/version"
 require "pdfjs_viewer-rails/helpers"
 
 module PdfjsViewer
+  # When the viewer is loaded on these origins, files can be loaded
+  # from any origin, otherwise only same-origin files are allowed.
+  mattr_accessor :hosted_viewer_origins do
+    ['null', 'http://mozilla.github.io', 'https://mozilla.github.io']
+  end
+  
   module Rails
     class Engine < ::Rails::Engine
       isolate_namespace PdfjsViewer


### PR DESCRIPTION
Closes #16.

I've changed the implementation to a solution that doesn't involve editing the `viewer.js` file.

The HOSTED_VIEWER_ORIGINS can now be configured in an initialiser:

``` ruby
PdfjsViewer.hosted_viewer_origins = ["http://somehost", "https://somehost"]
```
