### PR TITLE
Allow to load an external custom stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ an iframe.
 
 NOTE: The helper will render a full HTML document and should not be used in a layout.
 
+### Custom stylesheet
+
+To overwrite some styles in order to get a branded viewer, you can load a custom stylesheet:
+
+```ruby
+# initializers/pdfjs_viewer.rb
+
+PdfjsViewer.custom_stylesheet = 'pdfjs'
+```
+
+Prerequisites
+
+* `assets/stylesheets/pdfjs.css` must be created
+* `pdfjs.css` must be manually added to your precompiled assets (`Rails.application.config.assets.precompile`)
+
+
 ## Development
 
 Tests can be executed with:

--- a/app/views/pdfjs_viewer/viewer/_viewer.html.erb
+++ b/app/views/pdfjs_viewer/viewer/_viewer.html.erb
@@ -30,8 +30,11 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= title %></title>
 
-
     <%= stylesheet_link_tag "pdfjs_viewer/application", media: "all" %>
+
+    <% if PdfjsViewer.custom_stylesheet.present? %>
+      <%= stylesheet_link_tag "#{PdfjsViewer.custom_stylesheet}", media: 'all' %>
+    <% end %>
 
     <!-- This snippet is used in production (included from viewer.html) -->
     <link rel="resource" type="application/l10n" href="/pdfjs/web/locale/locale.properties"/>

--- a/lib/pdfjs_viewer-rails.rb
+++ b/lib/pdfjs_viewer-rails.rb
@@ -2,6 +2,9 @@ require "pdfjs_viewer-rails/version"
 require "pdfjs_viewer-rails/helpers"
 
 module PdfjsViewer
+
+  mattr_accessor :custom_stylesheet
+
   module Rails
     class Engine < ::Rails::Engine
       isolate_namespace PdfjsViewer


### PR DESCRIPTION
In order to get a branded viewer, I need to be able to overwrite some styles through an external stylesheet.

This PR aims to do that setting the custom stylesheet name through `PdfjsViewer.custom_stylesheet` and loading it into `_viewer.html.erb`.
