### PR TITLE
Avoid Rails autoloading issues by inherit directly

### DIFF
--- a/app/controllers/pdfjs_viewer/application_controller.rb
+++ b/app/controllers/pdfjs_viewer/application_controller.rb
@@ -1,4 +1,2 @@
-module PdfjsViewer
-  class ApplicationController < ActionController::Base
-  end
+class PdfjsViewer::ApplicationController < ActionController::Base
 end

--- a/app/controllers/pdfjs_viewer/viewer_controller.rb
+++ b/app/controllers/pdfjs_viewer/viewer_controller.rb
@@ -1,14 +1,12 @@
-module PdfjsViewer
-  class ViewerController < ApplicationController
-    layout false
+class PdfjsViewer::ViewerController < PdfjsViewer::ApplicationController
+  layout false
 
-    def full
-    end
+  def full
+  end
 
-    def minimal
-    end
-    
-    def reduced
-    end
+  def minimal
+  end
+
+  def reduced
   end
 end


### PR DESCRIPTION
We had an issue with rails lazy loading in development. We fetch the pdf on an internal path and "our" `ApplicationController` took precedence over yours. We fixed this by inheriting directly with the module itself.