### PR TITLE
Add a cache defeating per version query string to the pdf.worker.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ gemfile:
   - gemfiles/Gemfile.rails-5-1-stable
   - gemfiles/Gemfile.rails-5-2-stable
 
-before_install:
-    - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-    - gem install bundler -v '< 2'
+matrix:
+  exclude:
+    - rvm: 2.3
+      gemfile: gemfiles/Gemfile.rails-4-2-stable

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -66,6 +66,8 @@ PDFJS.cMapUrl = '/pdfjs/web/cmaps/';
 
 Replace all `url(images/` with `url(/pdfjs/web/images/`
 
+Take extra care here as there are a few instances of inconsistent naming across pdf.js releases! For example the upgrade to 1.10.100 was not a trivial find and replace.
+
 ## `app/views/pdfjs_viewer/viewer/_viewer.html.erb`
 
 Replace the whole content of `app/views/pdfjs_viewer/viewer/_viewer.html.erb` with `web/viewer.html` from the new pdf.js release.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -58,9 +58,11 @@ PDFJS.cMapUrl = '../web/cmaps/';
 with
 ``` javascript
 PDFJS.imageResourcesPath = '/pdfjs/web/images/';
-PDFJS.workerSrc = '/pdfjs/web/pdf.worker.js';
+PDFJS.workerSrc = '/pdfjs/web/pdf.worker.js?version=<version_number>';
 PDFJS.cMapUrl = '/pdfjs/web/cmaps/';
 ```
+
+The version is added as a query string above so we ensure users will get the matching version of the worker despite caching.
 
 ## `app/assets/stylesheets/pdfjs_viewer/pdfjs/viewer.css`
 

--- a/app/assets/javascripts/pdfjs_viewer/viewer.js
+++ b/app/assets/javascripts/pdfjs_viewer/viewer.js
@@ -941,7 +941,7 @@ var DEFAULT_SCALE_DELTA = 1.1;
 var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 function configure(PDFJS) {
   PDFJS.imageResourcesPath = '/pdfjs/web/images/';
-  PDFJS.workerSrc = '/pdfjs/web/pdf.worker.js';
+  PDFJS.workerSrc = '/pdfjs/web/pdf.worker.js?version=1.10.100';
   PDFJS.cMapUrl = '/pdfjs/web/cmaps/';
   PDFJS.cMapPacked = true;
 }


### PR DESCRIPTION
Users whom have previously accessed the viewer can end up using a cached old worker implementation. Adding a query string forces them to guaranteedly always get the correct one.