### PR TITLE
modernize gems and dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ gemspec
 
 group :test do
   gem 'capybara', '>= 2.1'
-  gem 'poltergeist', '~> 1.5'
+  gem 'apparition'
   gem 'puma'
 end

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ tested on S3:
 Tests can be executed with:
 
 ```
-$ bundle exec rake
+$ bin/rake
 ```
 
-This will render the sample.pdf using phantomjs and save screenshots into `test/sandbox`.
+This will render the sample.pdf using headless chrome and save screenshots into `test/sandbox`.
 
 ## License
 

--- a/gemfiles/Gemfile.rails-5-2-stable
+++ b/gemfiles/Gemfile.rails-5-2-stable
@@ -6,6 +6,6 @@ gem "rails", git: "https://github.com/rails/rails.git", branch: "5-2-stable"
 
 group :test do
   gem 'capybara', '>= 2.1'
-  gem 'poltergeist', '~> 1.5'
+  gem 'apparition'
   gem 'puma'
 end

--- a/gemfiles/Gemfile.rails-6-0-stable
+++ b/gemfiles/Gemfile.rails-6-0-stable
@@ -6,6 +6,6 @@ gem "rails", git: "https://github.com/rails/rails.git", branch: "6-0-stable"
 
 group :test do
   gem 'capybara', '>= 2.1'
-  gem 'poltergeist', '~> 1.5'
+  gem 'apparition'
   gem 'puma'
 end

--- a/pdfjs_viewer-rails.gemspec
+++ b/pdfjs_viewer-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "> 4.2.0"
-  s.add_dependency "sass-rails", "> 5.0"
+  s.add_dependency "sassc-rails", ">= 2.1"
   s.add_dependency "json", "> 1.8.4"
 
   s.add_development_dependency "sqlite3"

--- a/test/integration/viewer_test.rb
+++ b/test/integration/viewer_test.rb
@@ -83,8 +83,8 @@ class ViewerTest < ActionDispatch::IntegrationTest
 
   private
   def assert_rendered_pdf(output, screenshot:)
-    assert_match(/PDF a0f29a2f4968123b2e931593605583c8/, output)
     page.save_screenshot screenshot, full: true
+    assert_match(/PDF a0f29a2f4968123b2e931593605583c8/, output)
   end
 
   def capture(stream)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,8 +15,8 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
 end
 
+require 'capybara/apparition'
 require 'capybara/rails'
-require 'capybara/poltergeist'
 require "timeout"
 
 SANDBOX_PATH = Pathname.new(File.expand_path("sandbox", __dir__))
@@ -27,7 +27,7 @@ end
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
-  Capybara.default_driver = :poltergeist
+  Capybara.default_driver = :apparition
 
   def teardown
     super


### PR DESCRIPTION
Closes #50

This patch replaces the deprecated `sass-rails` gem with
`sassc-rails`. It  also modernizes the testing dependencies and now
uses a headless chrome driver (`apparition`) instead of `poltergeist`.