### PR TITLE
Add the "Rails 6 support" to the Changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add support for Rails 6
+
 ## 0.3.1
 
 - Add a cache defeating per version query string to the pdf.worker.js


### PR DESCRIPTION
This updates the Changelog for a possible 0.3.2 release.

Is it possible to release a new version of the gem?